### PR TITLE
allow naming unions

### DIFF
--- a/ReClass.NET/CodeGenerator/CppCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CppCodeGenerator.cs
@@ -474,7 +474,8 @@ namespace ReClassNET.CodeGenerator
 				WriteNodes(writer, unionNode.Nodes, logger);
 
 				writer.Indent--;
-				writer.WriteLine("};");
+
+				writer.WriteLine($"}} {node.Name};");
 			}
 			else
 			{

--- a/ReClass.NET/Nodes/UnionNode.cs
+++ b/ReClass.NET/Nodes/UnionNode.cs
@@ -63,6 +63,10 @@ namespace ReClassNET.Nodes
 			x = AddAddressOffset(context, x, y);
 
 			x = AddText(context, x, y, context.Settings.TypeColor, HotSpot.NoneId, "Union") + context.Font.Width;
+			if (!IsWrapped)
+			{
+				x = AddText(context, x, y, context.Settings.NameColor, HotSpot.NameId, Name) + context.Font.Width;
+			}
 
 			x = AddText(context, x, y, context.Settings.ValueColor, HotSpot.NoneId, $"[Nodes: {Nodes.Count}, Size: {MemorySize}]") + context.Font.Width;
 


### PR DESCRIPTION
Not a big deal in c++ code but is much better for rust bindgen'd structs.

Without naming we get random anon names like `__bindgen_union_ty1` etc